### PR TITLE
💣 Alpha v0.0.4 – New Moderation Command: /nuke

### DIFF
--- a/src/commands/moderation/nuke.ts
+++ b/src/commands/moderation/nuke.ts
@@ -1,0 +1,37 @@
+import { SlashCommandBuilder, ChannelType } from 'discord.js';
+import emoji from '../../../assets/emoji.json' assert { type: 'json' };
+
+export default {
+	data: new SlashCommandBuilder()
+		.setName('nuke')
+		.setDescription('Allow to delete and recreate a channel')
+		.addChannelOption((opt) =>
+			opt
+				.setName('channel')
+				.setDescription('Choose the channel you want to renew')
+				.addChannelTypes(ChannelType.GuildText),
+		),
+	async execute(interaction: CommandInteraction) {
+		const oldChannel : GuildText = interaction.options.getChannel(
+			'channel',
+		) || interaction.channel;
+		const pos: interger = channel.position;
+
+		oldChannel.clone().then((newchannel) => {
+			newchannel.setPosition(pos);
+			interaction.client.channels.fetch(newchannel.id).then(
+				channel => channel.send({
+					content: `${emoji.answer.yes} | ${newchannel} has been nuked by \`${interaction.user.username}\``,
+					ephermal: true,
+				}),
+			);
+			try {
+				oldChannel.delete();
+			}
+			catch (err) {
+				console.error(`⚠️ | Error when suppressing the channel\n\t${err}`);
+			}
+		});
+
+	},
+};


### PR DESCRIPTION
Boom. Cleanup has never been this clean. This update introduces a powerful new tool for moderators to quickly reset any text channel with style. 🚀

⸻

🔨 New Command: /nuke
	•	📁 What it does:
Deletes the current text channel and recreates it in the same position, with the same permissions.
	•	💬 Confirmation:
Sends a message in the newly created channel to confirm the action.
	•	🧠 Implemented in:
src/commands/moderation/nuke.ts
	•	🛡️ Permission-aware:
Only available to users with the appropriate moderation rights.

⸻

📌 This command is perfect for wiping spammy or cluttered channels while keeping the server structure intact.

Next up: bulk moderation tools? soft bans? 👀