### PR TITLE
🧪 Alpha v0.0.5 – Events, Nukes, Whitelists & Logs

### DIFF
--- a/src/commands/moderation/nuke.ts
+++ b/src/commands/moderation/nuke.ts
@@ -1,5 +1,25 @@
-import { SlashCommandBuilder, ChannelType } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder, ChannelType } from 'discord.js';
+import { prisma } from '../../lib/prisma.ts';
 import emoji from '../../../assets/emoji.json' assert { type: 'json' };
+
+async function isWhitelisted(userId: string, guildId: string): Promise<boolean> {
+	const userData: User = await prisma.user.findUnique({
+		where: {
+			id: userId,
+		},
+	});
+	const count: interger = await prisma.user.count({
+		where: {
+			id: userId,
+			WhitelistedGuilds: {
+				some: {
+					id: guildId,
+				},
+			},
+		},
+	});
+	return (userData.isOwner || userData.isBuyer || count);
+}
 
 export default {
 	data: new SlashCommandBuilder()
@@ -12,10 +32,17 @@ export default {
 				.addChannelTypes(ChannelType.GuildText),
 		),
 	async execute(interaction: CommandInteraction) {
+		if (!(await isWhitelisted(interaction.user.id, interaction.guild.id))) {
+			interaction.reply({
+				content: `${emoji.answer.no} | You're not whitelisted on this server`,
+				flags: MessageFlags.Ephemeral,
+			});
+			return;
+		}
 		const oldChannel : GuildText = interaction.options.getChannel(
 			'channel',
 		) || interaction.channel;
-		const pos: interger = channel.position;
+		const pos: interger = oldChannel.position;
 
 		oldChannel.clone().then((newchannel) => {
 			newchannel.setPosition(pos);
@@ -32,6 +59,5 @@ export default {
 				console.error(`⚠️ | Error when suppressing the channel\n\t${err}`);
 			}
 		});
-
 	},
 };

--- a/src/events/client/guildCreate.ts
+++ b/src/events/client/guildCreate.ts
@@ -116,7 +116,7 @@ export default {
 			}),
 		);
 		console.log(
-			`✅ | Guild ${guild.name} synchronisée avec ${guild.members.size} membres.`,
+			`✅ | Guild ${guild.name} synchronisée avec ${guild.memberCount} membres.`,
 		);
 	},
 };

--- a/src/events/client/guildUpdate.ts
+++ b/src/events/client/guildUpdate.ts
@@ -1,6 +1,20 @@
 import { Events, Guild, EmbedBuilder, channelMention } from 'discord.js';
 import { prisma } from '../../lib/prisma.ts';
 
+const verificationLevels: string[] = [
+	'Unrestricted',
+	'Low - must have a verified email',
+	'Medium - must be registered for 5 minutes',
+	'High - 10 minutes of membership required',
+	'Highest - verified phone required',
+];
+
+const explicitContentLevels: string[] = [
+	'No Scanning Enabled',
+	'Scanning content from members without a role',
+	'Scanning content from all members',
+];
+
 export default {
 	name: Events.GuildUpdate,
 	async execute(oldGuild, newGuild) {
@@ -31,10 +45,10 @@ export default {
 				toPrint += `- Language:\n\`${oldGuild.preferredLocale}\` => \`${newGuild.preferredLocale}\`\n`;
 			}
 			if (oldGuild.verificationLevel !== newGuild.verificationLevel) {
-				toPrint += `- Verification:\n\`${oldGuild.verificationLevel}\` => \`${newGuild.verificationLevel}\`\n`;
+				toPrint += `- Verification:\n\`${verificationLevels[oldGuild.verificationLevel]}\` => \`${verificationLevels[newGuild.verificationLevel]}\`\n`;
 			}
 			if (oldGuild.explicitContentFilter !== newGuild.explicitContentFilter) {
-				toPrint += `- Filter:\n\`${oldGuild.explicitContentFilter}\` => \`${newGuild.explicitContentFilter}\`\n`;
+				toPrint += `- Filter:\n\`${explicitContentLevels[oldGuild.explicitContentFilter]}\` => \`${explicitContentLevels[newGuild.explicitContentFilter]}\`\n`;
 			}
 			if (oldGuild.premiumTier !== newGuild.premiumTier) {
 				toPrint += `- Filter:\n\`${oldGuild.premiumTier}\` => \`${newGuild.premiumTier}\`\n`;

--- a/src/events/client/guildUpdate.ts
+++ b/src/events/client/guildUpdate.ts
@@ -1,0 +1,55 @@
+import { Events, Guild, EmbedBuilder, channelMention } from 'discord.js';
+import { prisma } from '../../lib/prisma.ts';
+
+export default {
+	name: Events.GuildUpdate,
+	async execute(oldGuild, newGuild) {
+		const guildData: Guild = await prisma.guild.findUnique({
+			where: {
+				id: newGuild.id,
+			},
+		});
+		if (guildData.logServer) {
+			let toPrint: string = 'The update of the guild had changes theses thing\n';
+			const logChannel = await newGuild.client.channels
+				.fetch(guildData.logServer)
+				.catch(() => null);
+			if (!logChannel || !logChannel.isTextBased()) {return;}
+			if (oldGuild.name !== newGuild.name) {
+				toPrint += `- Name:\n\`${oldGuild.name}\` => \`${newGuild.name}\`\n`;
+			}
+			if (oldGuild.description !== newGuild.description) {
+				toPrint += `- Description:\n\`${oldGuild.description}\` => \`${newGuild.description}\`\n`;
+			}
+			if (oldGuild.afkChannelId !== newGuild.afkChannelId) {
+				toPrint += `- AfkChannel:\n${oldGuild.afkChannelId ? channelMention(oldGuild.afkChannelId) : 'Not defined'} => ${newGuild.afkChannelId ? channelMention(newGuild.afkChannelId) : 'Not defined'}\n`;
+			}
+			if (oldGuild.afkTimeout !== newGuild.afkTimeout) {
+				toPrint += `- Timeout:\n\`${oldGuild.afkTimeout / 60}m\` => \`${newGuild.afkTimeout / 60}m\`\n`;
+			}
+			if (oldGuild.preferredLocale !== newGuild.preferredLocale) {
+				toPrint += `- Language:\n\`${oldGuild.preferredLocale}\` => \`${newGuild.preferredLocale}\`\n`;
+			}
+			if (oldGuild.verificationLevel !== newGuild.verificationLevel) {
+				toPrint += `- Verification:\n\`${oldGuild.verificationLevel}\` => \`${newGuild.verificationLevel}\`\n`;
+			}
+			if (oldGuild.explicitContentFilter !== newGuild.explicitContentFilter) {
+				toPrint += `- Filter:\n\`${oldGuild.explicitContentFilter}\` => \`${newGuild.explicitContentFilter}\`\n`;
+			}
+			if (oldGuild.premiumTier !== newGuild.premiumTier) {
+				toPrint += `- Filter:\n\`${oldGuild.premiumTier}\` => \`${newGuild.premiumTier}\`\n`;
+			}
+			const toRep = new EmbedBuilder()
+				.setColor(`${guildData.color}`)
+				.setFooter({
+					text: guildData.footer,
+				})
+				.setDescription(`${toPrint}`);
+			logChannel.send({
+				embeds: [
+					toRep,
+				],
+			});
+		}
+	},
+};


### PR DESCRIPTION
This update introduces major improvements to server logging, moderation commands, and buyer notifications. From powerful event tracking to enhanced security and cleaner UX, v0.0.5-alpha brings structure and control to your bot’s admin features. 🔧📋

⸻

📣 Buyer Notifications & Guild Events

Your buyers now stay fully informed via DM when major bot events occur.
	•	🟢 On Bot Ready → Sends a DM with total guild count, user count, and startup time.
	•	➕ On Guild Join → Sends a DM with:
	•	Guild name & ID
	•	👥 Member count
	•	👑 Owner ID
	•	🔗 Instant invite (via getGuildInvite())
	•	➖ On Guild Leave → Sends a DM with:
	•	Guild name
	•	Owner ID
	•	Member count
🗂️ guildCreate.ts, guildDelete.ts, ready.ts

⸻

🧾 Guild Update Logging – Audit-Ready

Track all major guild config changes in real time. Logged as embeds to your log channel:
	•	🏷️ Name & Description
	•	😴 AFK channel / timeout
	•	🌍 Locale
	•	🛡️ Verification level
	•	🚫 Content filter
	•	💎 Boost tier
🗂️ guildUpdate.ts

⸻

💣 Moderation Command: /nuke (Now Secured)

Delete and recreate a text channel in one clean move — now with enforced security:
	•	✅ Whitelist checks:
	•	Server owners
	•	Buyers
	•	Whitelisted guild users
	•	🛑 Unauthorized users receive an ephemeral error.
	•	🎯 Channel position & permissions are preserved.
	•	📢 A confirmation message is sent in the recreated channel.
🗂️ nuke.ts

⸻

🧯 UX & Accuracy Enhancements
	•	🕒 /logs role collector now times out after 1 minute with user feedback.
	•	🧮 Fixed member count reporting (memberCount instead of members.size).

⸻

📌 This release completes the core infrastructure for event visibility, command security, and moderator tooling — perfect for alpha testers.