### PR TITLE
Guild Language Support & Workflow Update

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/migrations/001_create_enums.sql
+++ b/migrations/001_create_enums.sql
@@ -1,2 +1,3 @@
 CREATE TYPE bot_presence AS ENUM ('online', 'idle', 'dnd', 'invisible');
 CREATE TYPE bot_activity AS ENUM ('Playing', 'Streaming', 'Listening', 'Watching', 'Competing');
+CREATE TYPE guild_lang AS ENUM ('en', 'fr');

--- a/migrations/002_create_tables.sql
+++ b/migrations/002_create_tables.sql
@@ -26,6 +26,7 @@ ON CONFLICT (user_id) DO NOTHING;
 
 CREATE TABLE guilds (
     guild_id TEXT PRIMARY KEY,
+	guild_lang	guild_lang NOT NULL DEFAULT 'en',
 
     log_enable   BOOLEAN NOT NULL DEFAULT FALSE,
     log_category TEXT,

--- a/src/models/guild.rs
+++ b/src/models/guild.rs
@@ -1,8 +1,16 @@
 use sqlx::FromRow;
 
+#[derive(Debug, Clone, sqlx::Type)]
+#[sqlx(type_name = "guild_lang", rename_all = "lowercase")]
+pub enum GuildLang {
+    EN,
+    FR,
+}
+
 #[derive(Debug, FromRow)]
 pub struct DbGuild {
     pub guild_id: String,
+    pub guild_lang: GuildLang,
 
     pub log_enable: bool,
     pub log_category: Option<String>,


### PR DESCRIPTION
This PR introduces **guild language preference** support and updates the Rust workflow configuration.

### Key Changes

#### Database Schema
- Added `guild_lang` enum type (`'en'`, `'fr'`) in `001_create_enums.sql`
- Added `guild_lang` column to `guilds` table (defaults to `'en'`) in `002_create_tables.sql`

#### Rust Models
- Added `GuildLang` enum in `src/models/guild.rs`
- Updated `DbGuild` struct with `guild_lang` field

#### CI/CD
- Updated Rust workflow (`.github/workflows/rust.yml`) to use `main` branch instead of `master`

### Impact
- Guilds can now specify their preferred language (English/French)
- Database schema is future-proof for additional language support
- CI/CD pipeline now aligns with modern branch naming conventions

### Files Changed
- Database migrations (`001_create_enums.sql`, `002_create_tables.sql`)
- Rust models (`src/models/guild.rs`)
- GitHub workflow (`.github/workflows/rust.yml`)